### PR TITLE
Make timestamped signatures compatible with Python

### DIFF
--- a/itsdangerous.go
+++ b/itsdangerous.go
@@ -14,9 +14,6 @@ import (
 	"time"
 )
 
-// 2011/01/01 in UTC
-const EPOCH = 1293840000
-
 // Encodes a single string. The resulting string is safe for putting into URLs.
 func base64Encode(src []byte) string {
 	s := base64.URLEncoding.EncodeToString(src)
@@ -41,8 +38,12 @@ func base64Decode(s string) ([]byte, error) {
 	return b, nil
 }
 
+// Function used to obtain the current time. Defaults to time.Now, but can be
+// overridden eg for unit tests to simulate a different current time.
+var NowFunc = time.Now
+
 // Returns the current timestamp.  This implementation returns the
-// seconds since 1/1/2011.
+// seconds since January 1, 1970 UTC.
 func getTimestamp() uint32 {
-	return uint32(time.Now().Unix() - EPOCH)
+	return uint32(NowFunc().Unix())
 }

--- a/itsdangerous.go
+++ b/itsdangerous.go
@@ -44,6 +44,6 @@ var NowFunc = time.Now
 
 // Returns the current timestamp.  This implementation returns the
 // seconds since January 1, 1970 UTC.
-func getTimestamp() uint32 {
-	return uint32(NowFunc().Unix())
+func getTimestamp() int64 {
+	return NowFunc().Unix()
 }

--- a/signature.go
+++ b/signature.go
@@ -142,13 +142,8 @@ type TimestampSignature struct {
 
 // Sign the given string.
 func (s *TimestampSignature) Sign(value string) (string, error) {
-	buf := new(bytes.Buffer)
-
-	if err := binary.Write(buf, binary.BigEndian, getTimestamp()); err != nil {
-		return "", err
-	}
-
-	tsBytes := buf.Bytes()
+	tsBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(tsBytes, uint64(getTimestamp()))
 	// trim leading zeroes
 	tsBytes = bytes.TrimLeft(tsBytes, "\x00")
 
@@ -189,11 +184,7 @@ func (s *TimestampSignature) Unsign(value string, maxAge uint32) (string, error)
 		)
 	}
 
-	var timestamp int64
-	var buf = bytes.NewReader([]byte(tsBytes))
-	if err = binary.Read(buf, binary.BigEndian, &timestamp); err != nil {
-		return "", err
-	}
+	var timestamp = int64(binary.BigEndian.Uint64(tsBytes))
 
 	if maxAge > 0 {
 		if age := getTimestamp() - timestamp; uint32(age) > maxAge {

--- a/signature.go
+++ b/signature.go
@@ -148,7 +148,11 @@ func (s *TimestampSignature) Sign(value string) (string, error) {
 		return "", err
 	}
 
-	ts := base64Encode(buf.Bytes())
+	tsBytes := buf.Bytes()
+	// trim leading zeroes
+	tsBytes = bytes.TrimLeft(tsBytes, "\x00")
+
+	ts := base64Encode(tsBytes)
 	val := value + s.Sep + ts
 
 	sig, err := s.Get(val)
@@ -160,8 +164,6 @@ func (s *TimestampSignature) Sign(value string) (string, error) {
 
 // Unsign the given string.
 func (s *TimestampSignature) Unsign(value string, maxAge uint32) (string, error) {
-	var timestamp uint32
-
 	result, err := s.Signature.Unsign(value)
 	if err != nil {
 		return "", err
@@ -175,18 +177,26 @@ func (s *TimestampSignature) Unsign(value string, maxAge uint32) (string, error)
 	li := strings.LastIndex(result, s.Sep)
 	val, ts := result[:li], result[li+len(s.Sep):]
 
-	sig, err := base64Decode(ts)
+	tsBytes, err := base64Decode(ts)
 	if err != nil {
 		return "", err
 	}
+	// left pad up to 8 bytes
+	if len(tsBytes) < 8 {
+		tsBytes = append(
+			make([]byte, 8-len(tsBytes)),
+			tsBytes...,
+		)
+	}
 
-	buf := bytes.NewReader([]byte(sig))
+	var timestamp int64
+	var buf = bytes.NewReader([]byte(tsBytes))
 	if err = binary.Read(buf, binary.BigEndian, &timestamp); err != nil {
 		return "", err
 	}
 
 	if maxAge > 0 {
-		if age := getTimestamp() - timestamp; age > maxAge {
+		if age := getTimestamp() - timestamp; uint32(age) > maxAge {
 			return "", fmt.Errorf("signature age %d > %d seconds", age, maxAge)
 		}
 	}

--- a/signature_test.go
+++ b/signature_test.go
@@ -44,6 +44,9 @@ func TestTimestampSignatureSign(t *testing.T) {
 			expected: "my string.Zva6YA.aqBNzGvNEDkO6RGFPEX1HIhz0vU"},
 		{input: "my string", now: time.Date(2024, 9, 27, 15, 0, 0, 0, time.UTC),
 			expected: "my string.ZvbIcA.VVQqPkaZ-YQaLHomuudMzTiw45Q"},
+		// Test with timestamp > 4 bytes
+		{input: "my string", now: time.Date(2124, 9, 27, 15, 0, 0, 0, time.UTC),
+			expected: "my string.ASMOinA.eGqsFVFmYbv8t7tXD8PX7LHSXdY"},
 	}
 	for _, test := range tests {
 		test := test
@@ -83,6 +86,11 @@ func TestTimestampSignatureUnsign(t *testing.T) {
 		// maxAge zero always validates
 		{input: "my string.Zva6YA.aqBNzGvNEDkO6RGFPEX1HIhz0vU", expected: "my string",
 			now: time.Date(2024, 9, 27, 14, 5, 1, 0, time.UTC), maxAge: 0},
+		// Test with timestamp > 4 bytes
+		{input: "my string.ASMOinA.eGqsFVFmYbv8t7tXD8PX7LHSXdY", expected: "my string",
+			now: time.Date(2124, 9, 27, 15, 4, 59, 0, time.UTC), maxAge: 5 * 60},
+		{input: "my string.ASMOinA.eGqsFVFmYbv8t7tXD8PX7LHSXdY", expectError: true,
+			now: time.Date(2124, 9, 27, 15, 5, 1, 0, time.UTC), maxAge: 5 * 60},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
This fixes a few issues relating to handling of timestamps to make this compatible with the Python version:

The Python implementation initially used an epoch of 2011/01/01, but this was dropped in favour of the standard unix epoch [prior to version 1.0.0](https://github.com/pallets/itsdangerous/issues/46). This implementation had not been updated to reflect this change

Fix handling for timestamps > 4 bytes - the Python implementation serialises the timestamp as an 8-byte integer
([using pack with '>Q'](https://github.com/pallets/itsdangerous/blob/2.2.0/src/itsdangerous/encoding.py#L44)), and then [trims leading zeroes](https://github.com/pallets/itsdangerous/blob/2.2.0/src/itsdangerous/encoding.py#L50). For current timestamps, this output is the same as for a 4-byte integer. This implementation was parsing the timestamp assuming a fixed 4-byte integer representation, which means it would break when the current timestamp spills over into more than 4 bytes.