### PR TITLE
Refine the public API interface

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -8,7 +8,7 @@ import (
 // SigningAlgorithm provides interfaces to generate and verify signature
 type SigningAlgorithm interface {
 	GetSignature(key []byte, value string) []byte
-	VerifySignature(key []byte, value string, sig []byte) bool
+	VerifySignature(key []byte, value string, signature []byte) bool
 }
 
 // HMACAlgorithm provides signature generation using HMACs.
@@ -24,9 +24,9 @@ func (a *HMACAlgorithm) GetSignature(key []byte, value string) []byte {
 }
 
 // VerifySignature verifies the given signature matches the expected signature.
-func (a *HMACAlgorithm) VerifySignature(key []byte, value string, sig []byte) bool {
+func (a *HMACAlgorithm) VerifySignature(key []byte, value string, signature []byte) bool {
 	return hmac.Equal(
-		sig,
+		signature,
 		a.GetSignature(key, value),
 	)
 }

--- a/algorithm.go
+++ b/algorithm.go
@@ -19,7 +19,6 @@ type HMACAlgorithm struct {
 
 // GetSignature returns the signature for the given key and value.
 func (a *HMACAlgorithm) GetSignature(key, value string) []byte {
-	a.DigestMethod().Reset()
 	h := hmac.New(func() hash.Hash { return a.DigestMethod() }, []byte(key))
 	h.Write([]byte(value))
 	return h.Sum(nil)

--- a/algorithm.go
+++ b/algorithm.go
@@ -2,14 +2,13 @@ package itsdangerous
 
 import (
 	"crypto/hmac"
-	"crypto/subtle"
 	"hash"
 )
 
 // SigningAlgorithm provides interfaces to generate and verify signature
 type SigningAlgorithm interface {
-	GetSignature(key, value string) []byte
-	VerifySignature(key, value string, sig []byte) bool
+	GetSignature(key []byte, value string) []byte
+	VerifySignature(key []byte, value string, sig []byte) bool
 }
 
 // HMACAlgorithm provides signature generation using HMACs.
@@ -18,14 +17,16 @@ type HMACAlgorithm struct {
 }
 
 // GetSignature returns the signature for the given key and value.
-func (a *HMACAlgorithm) GetSignature(key, value string) []byte {
-	h := hmac.New(a.DigestMethod, []byte(key))
+func (a *HMACAlgorithm) GetSignature(key []byte, value string) []byte {
+	h := hmac.New(a.DigestMethod, key)
 	h.Write([]byte(value))
 	return h.Sum(nil)
 }
 
 // VerifySignature verifies the given signature matches the expected signature.
-func (a *HMACAlgorithm) VerifySignature(key, value string, sig []byte) bool {
-	eq := subtle.ConstantTimeCompare(sig, []byte(a.GetSignature(key, value)))
-	return eq == 1
+func (a *HMACAlgorithm) VerifySignature(key []byte, value string, sig []byte) bool {
+	return hmac.Equal(
+		sig,
+		a.GetSignature(key, value),
+	)
 }

--- a/algorithm.go
+++ b/algorithm.go
@@ -19,7 +19,7 @@ type HMACAlgorithm struct {
 
 // GetSignature returns the signature for the given key and value.
 func (a *HMACAlgorithm) GetSignature(key, value string) []byte {
-	h := hmac.New(func() hash.Hash { return a.DigestMethod() }, []byte(key))
+	h := hmac.New(a.DigestMethod, []byte(key))
 	h.Write([]byte(value))
 	return h.Sum(nil)
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,22 @@
+package itsdangerous
+
+import "fmt"
+
+type InvalidSignatureError struct {
+	err error
+}
+
+func (e InvalidSignatureError) Error() string { return e.err.Error() }
+func (e InvalidSignatureError) Unwrap() error { return e.err }
+
+type SignatureExpiredError struct {
+	age, maxAge int64
+}
+
+func (e SignatureExpiredError) Error() string {
+	return fmt.Sprintf("signature age %d > %d seconds", e.age, e.maxAge)
+}
+
+func signatureExpired(age, maxAge int64) error {
+	return InvalidSignatureError{SignatureExpiredError{age: age, maxAge: maxAge}}
+}

--- a/python_examples/generate_examples.py
+++ b/python_examples/generate_examples.py
@@ -1,0 +1,18 @@
+from freezegun import freeze_time
+from itsdangerous import Signer, TimestampSigner
+
+key = "secret_key"
+salt = "salt"
+
+print(f"Signer examples {key=} {salt=}")
+s = Signer(key, salt)
+print("  'my string' ->", s.sign("my string"))
+print("  'aaaaaaaaaaaaaaaa' ->", s.sign("aaaaaaaaaaaaaaaa"))
+print()
+
+print(f"TimestampSigner examples {key=} {salt=}")
+s = TimestampSigner(key, salt)
+with freeze_time("2024-09-27T14:00:00Z"):
+    print("  'my string' ->", s.sign("my string"), "at time 2024-09-27T14:00:00Z")
+with freeze_time("2024-09-27T15:00:00Z"):
+    print("  'my string' ->", s.sign("my string"), "at time 2024-09-27T15:00:00Z")

--- a/signature.go
+++ b/signature.go
@@ -45,7 +45,7 @@ func (s *Signature) DeriveKey() (string, error) {
 		h.Write([]byte(s.Salt + "signer" + s.SecretKey))
 		key = string(h.Sum(nil))
 	case "hmac":
-		h := hmac.New(func() hash.Hash { return s.DigestMethod() }, []byte(s.SecretKey))
+		h := hmac.New(s.DigestMethod, []byte(s.SecretKey))
 		h.Write([]byte(s.Salt))
 		key = string(h.Sum(nil))
 	case "none":

--- a/signature.go
+++ b/signature.go
@@ -35,8 +35,6 @@ func (s *Signature) DeriveKey() (string, error) {
 	var key string
 	var err error
 
-	s.DigestMethod().Reset()
-
 	switch s.KeyDerivation {
 	case "concat":
 		h := s.DigestMethod()

--- a/signer.go
+++ b/signer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash"
 	"strings"
+	"time"
 )
 
 // Signer can sign bytes and unsign it and validate the signature
@@ -173,7 +174,7 @@ func (s *TimestampSigner) Sign(value string) (string, error) {
 }
 
 // Unsign the given string.
-func (s *TimestampSigner) Unsign(value string, maxAge uint32) (string, error) {
+func (s *TimestampSigner) Unsign(value string, maxAge time.Duration) (string, error) {
 	result, err := s.Signer.Unsign(value)
 	if err != nil {
 		return "", err
@@ -202,8 +203,9 @@ func (s *TimestampSigner) Unsign(value string, maxAge uint32) (string, error) {
 	var timestamp = int64(binary.BigEndian.Uint64(tsBytes))
 
 	if maxAge > 0 {
-		if age := getTimestamp() - timestamp; uint32(age) > maxAge {
-			return "", fmt.Errorf("signature age %d > %d seconds", age, maxAge)
+		maxAgeSecs := int64(maxAge.Seconds())
+		if age := getTimestamp() - timestamp; age > maxAgeSecs {
+			return "", fmt.Errorf("signature age %d > %d seconds", age, maxAgeSecs)
 		}
 	}
 	return val, nil

--- a/signer.go
+++ b/signer.go
@@ -31,27 +31,27 @@ type Signer struct {
 // DeriveKey generates a key derivation. Keep in mind that the key derivation in itsdangerous
 // is not intended to be used as a security method to make a complex key out of a short password.
 // Instead you should use large random secret keys.
-func (s *Signer) DeriveKey() (string, error) {
-	var key string
+func (s *Signer) DeriveKey() ([]byte, error) {
+	var key []byte
 	var err error
 
 	switch s.KeyDerivation {
 	case "concat":
 		h := s.DigestMethod()
 		h.Write([]byte(s.Salt + s.SecretKey))
-		key = string(h.Sum(nil))
+		key = h.Sum(nil)
 	case "django-concat":
 		h := s.DigestMethod()
 		h.Write([]byte(s.Salt + "signer" + s.SecretKey))
-		key = string(h.Sum(nil))
+		key = h.Sum(nil)
 	case "hmac":
 		h := hmac.New(s.DigestMethod, []byte(s.SecretKey))
 		h.Write([]byte(s.Salt))
-		key = string(h.Sum(nil))
+		key = h.Sum(nil)
 	case "none":
-		key = s.SecretKey
+		key = []byte(s.SecretKey)
 	default:
-		key, err = "", errors.New("unknown key derivation method")
+		key, err = nil, errors.New("unknown key derivation method")
 	}
 	return key, err
 }

--- a/signer.go
+++ b/signer.go
@@ -28,8 +28,15 @@ type Signer struct {
 	Algorithm     SigningAlgorithm
 }
 
-// NewSigner creates a new Signer
-func NewSigner(secret, salt, sep, derivation string, digest func() hash.Hash, algo SigningAlgorithm) *Signer {
+// NewSigner creates a new Signer with the given secret and salt. All other
+// properties will be set to match the Python itsdangerous defaults.
+func NewSigner(secret, salt string) *Signer {
+	return NewSignerWithOptions(secret, salt, "", "", nil, nil)
+}
+
+// NewSignerWithOptions creates a new Signer allowing overiding the default
+// properties.
+func NewSignerWithOptions(secret, salt, sep, derivation string, digest func() hash.Hash, algo SigningAlgorithm) *Signer {
 	if salt == "" {
 		salt = "itsdangerous.Signer"
 	}
@@ -138,9 +145,17 @@ type TimestampSigner struct {
 	Signer
 }
 
-// NewTimestampSigner creates a new TimestampSigner
-func NewTimestampSigner(secret, salt, sep, derivation string, digest func() hash.Hash, algo SigningAlgorithm) *TimestampSigner {
-	s := NewSigner(secret, salt, sep, derivation, digest, algo)
+// NewTimestampSigner creates a new TimestampSigner with the given secret and
+// salt. All other properties will be set to match the Python itsdangerous
+// defaults.
+func NewTimestampSigner(secret, salt string) *TimestampSigner {
+	return NewTimestampSignerWithOptions(secret, salt, "", "", nil, nil)
+}
+
+// NewTimestampSignerWithOptions creates a new TimestampSigner allowing
+// overiding the default properties.
+func NewTimestampSignerWithOptions(secret, salt, sep, derivation string, digest func() hash.Hash, algo SigningAlgorithm) *TimestampSigner {
+	s := NewSignerWithOptions(secret, salt, sep, derivation, digest, algo)
 	return &TimestampSigner{Signer: *s}
 }
 

--- a/signer.go
+++ b/signer.go
@@ -115,11 +115,10 @@ func (s *Signer) Sign(value string) string {
 
 // Unsign the given string.
 func (s *Signer) Unsign(signed string) (string, error) {
-	if !strings.Contains(signed, s.sep) {
+	li := strings.LastIndex(signed, s.sep)
+	if li < 0 {
 		return "", fmt.Errorf("no %s found in value", s.sep)
 	}
-
-	li := strings.LastIndex(signed, s.sep)
 	value, sig := signed[:li], signed[li+len(s.sep):]
 
 	if ok, _ := s.verifySignature(value, sig); ok == true {
@@ -172,12 +171,11 @@ func (s *TimestampSigner) Unsign(value string, maxAge time.Duration) (string, er
 		return "", err
 	}
 
-	// If there is no timestamp in the result there is something seriously wrong.
-	if !strings.Contains(result, s.sep) {
+	li := strings.LastIndex(result, s.sep)
+	if li < 0 {
+		// If there is no timestamp in the result there is something seriously wrong.
 		return "", errors.New("timestamp missing")
 	}
-
-	li := strings.LastIndex(result, s.sep)
 	val, ts := result[:li], result[li+len(s.sep):]
 
 	tsBytes, err := base64Decode(ts)

--- a/signer.go
+++ b/signer.go
@@ -148,11 +148,7 @@ func (s *TimestampSigner) Sign(value string) (string, error) {
 	ts := base64Encode(tsBytes)
 	val := value + s.Sep + ts
 
-	sig, err := s.GetSignature(val)
-	if err != nil {
-		return "", err
-	}
-	return val + s.Sep + sig, nil
+	return s.Signer.Sign(val)
 }
 
 // Unsign the given string.

--- a/signer_test.go
+++ b/signer_test.go
@@ -20,10 +20,7 @@ func TestSignerSign(t *testing.T) {
 		t.Run(test.input, func(t *testing.T) {
 			sig := NewSigner("secret_key", "salt")
 
-			actual, err := sig.Sign(test.input)
-			if err != nil {
-				t.Fatalf("Sign(%s) returned error: %s", test.input, err)
-			}
+			actual := sig.Sign(test.input)
 			if actual != test.expected {
 				t.Errorf("Sign(%s) got %s; want %s", test.input, actual, test.expected)
 			}
@@ -86,10 +83,7 @@ func TestTimestampSignerSign(t *testing.T) {
 
 			sig := NewTimestampSigner("secret_key", "salt")
 
-			actual, err := sig.Sign(test.input)
-			if err != nil {
-				t.Fatalf("Sign(%s) returned error: %s", test.input, err)
-			}
+			actual := sig.Sign(test.input)
 			if actual != test.expected {
 				t.Errorf("Sign(%s) got %#v; want %#v", test.input, actual, test.expected)
 			}

--- a/signer_test.go
+++ b/signer_test.go
@@ -102,23 +102,23 @@ func TestTimestampSignerUnsign(t *testing.T) {
 		input       string
 		expected    string
 		now         time.Time
-		maxAge      uint32
+		maxAge      time.Duration
 		expectError bool
 	}{
 		// Signature within maxAge
 		{input: "my string.Zva6YA.aqBNzGvNEDkO6RGFPEX1HIhz0vU", expected: "my string",
-			now: time.Date(2024, 9, 27, 14, 4, 59, 0, time.UTC), maxAge: 5 * 60},
+			now: time.Date(2024, 9, 27, 14, 4, 59, 0, time.UTC), maxAge: 5 * time.Minute},
 		// signature expired
 		{input: "my string.Zva6YA.aqBNzGvNEDkO6RGFPEX1HIhz0vU", expectError: true,
-			now: time.Date(2024, 9, 27, 14, 5, 1, 0, time.UTC), maxAge: 5 * 60},
+			now: time.Date(2024, 9, 27, 14, 5, 1, 0, time.UTC), maxAge: 5 * time.Minute},
 		// maxAge zero always validates
 		{input: "my string.Zva6YA.aqBNzGvNEDkO6RGFPEX1HIhz0vU", expected: "my string",
 			now: time.Date(2024, 9, 27, 14, 5, 1, 0, time.UTC), maxAge: 0},
 		// Test with timestamp > 4 bytes
 		{input: "my string.ASMOinA.eGqsFVFmYbv8t7tXD8PX7LHSXdY", expected: "my string",
-			now: time.Date(2124, 9, 27, 15, 4, 59, 0, time.UTC), maxAge: 5 * 60},
+			now: time.Date(2124, 9, 27, 15, 4, 59, 0, time.UTC), maxAge: 5 * time.Minute},
 		{input: "my string.ASMOinA.eGqsFVFmYbv8t7tXD8PX7LHSXdY", expectError: true,
-			now: time.Date(2124, 9, 27, 15, 5, 1, 0, time.UTC), maxAge: 5 * 60},
+			now: time.Date(2124, 9, 27, 15, 5, 1, 0, time.UTC), maxAge: 5 * time.Minute},
 	}
 	for _, test := range tests {
 		test := test

--- a/signer_test.go
+++ b/signer_test.go
@@ -11,15 +11,15 @@ func assert(t *testing.T, actual, expected string) {
 	}
 }
 
-func TestSignatureSign(t *testing.T) {
-	s := NewSignature("secret-key", "", "", "", nil, nil)
+func TestSignerSign(t *testing.T) {
+	s := NewSigner("secret-key", "", "", "", nil, nil)
 	expected := "my string.wh6tMHxLgJqB6oY1uT73iMlyrOA"
 	actual, _ := s.Sign("my string")
 	assert(t, actual, expected)
 }
 
-func TestSignatureUnsign(t *testing.T) {
-	s := NewSignature("secret-key", "", "", "", nil, nil)
+func TestSignerUnsign(t *testing.T) {
+	s := NewSigner("secret-key", "", "", "", nil, nil)
 	expected := "my string"
 	actual, _ := s.Unsign("my string.wh6tMHxLgJqB6oY1uT73iMlyrOA")
 	assert(t, actual, expected)
@@ -34,7 +34,7 @@ Examples generated in Python as follows:
 		print(s.sign("my string"))
 */
 
-func TestTimestampSignatureSign(t *testing.T) {
+func TestTimestampSignerSign(t *testing.T) {
 	tests := []struct {
 		input    string
 		now      time.Time
@@ -56,7 +56,7 @@ func TestTimestampSignatureSign(t *testing.T) {
 				defer func() { NowFunc = time.Now }()
 			}
 
-			sig := NewTimestampSignature("secret_key", "salt", "", "", nil, nil)
+			sig := NewTimestampSigner("secret_key", "salt", "", "", nil, nil)
 
 			actual, err := sig.Sign(test.input)
 			if err != nil {
@@ -69,7 +69,7 @@ func TestTimestampSignatureSign(t *testing.T) {
 	}
 }
 
-func TestTimestampSignatureUnsign(t *testing.T) {
+func TestTimestampSignerUnsign(t *testing.T) {
 	tests := []struct {
 		input       string
 		expected    string
@@ -100,7 +100,7 @@ func TestTimestampSignatureUnsign(t *testing.T) {
 				defer func() { NowFunc = time.Now }()
 			}
 
-			sig := NewTimestampSignature("secret_key", "salt", "", "", nil, nil)
+			sig := NewTimestampSigner("secret_key", "salt", "", "", nil, nil)
 
 			actual, err := sig.Unsign(test.input, test.maxAge)
 			if test.expectError {

--- a/signer_test.go
+++ b/signer_test.go
@@ -36,6 +36,8 @@ func TestSignerUnsign(t *testing.T) {
 	}{
 		{input: "my string.xv0r21ogoygusbkJA01c4OxsAio", expected: "my string"},
 		{input: "altered string.xv0r21ogoygusbkJA01c4OxsAio", expectError: true},
+		// missing separator
+		{input: "my stringxv0r21ogoygusbkJA01c4OxsAio", expectError: true},
 	}
 	for _, test := range tests {
 		test := test
@@ -113,6 +115,9 @@ func TestTimestampSignerUnsign(t *testing.T) {
 			now: time.Date(2124, 9, 27, 15, 4, 59, 0, time.UTC), maxAge: 5 * time.Minute},
 		{input: "my string.ASMOinA.eGqsFVFmYbv8t7tXD8PX7LHSXdY", expectError: true,
 			now: time.Date(2124, 9, 27, 15, 5, 1, 0, time.UTC), maxAge: 5 * time.Minute},
+		// Test with missing timestamp
+		{input: "my string.xv0r21ogoygusbkJA01c4OxsAio", expectError: true,
+			now: time.Date(2024, 9, 27, 14, 4, 59, 0, time.UTC), maxAge: 5 * time.Minute},
 	}
 	for _, test := range tests {
 		test := test

--- a/signer_test.go
+++ b/signer_test.go
@@ -18,7 +18,7 @@ func TestSignerSign(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.input, func(t *testing.T) {
-			sig := NewSigner("secret_key", "salt", "", "", nil, nil)
+			sig := NewSigner("secret_key", "salt")
 
 			actual, err := sig.Sign(test.input)
 			if err != nil {
@@ -43,7 +43,7 @@ func TestSignerUnsign(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.input, func(t *testing.T) {
-			sig := NewSigner("secret_key", "salt", "", "", nil, nil)
+			sig := NewSigner("secret_key", "salt")
 
 			actual, err := sig.Unsign(test.input)
 			if test.expectError {
@@ -84,7 +84,7 @@ func TestTimestampSignerSign(t *testing.T) {
 				defer func() { NowFunc = time.Now }()
 			}
 
-			sig := NewTimestampSigner("secret_key", "salt", "", "", nil, nil)
+			sig := NewTimestampSigner("secret_key", "salt")
 
 			actual, err := sig.Sign(test.input)
 			if err != nil {
@@ -128,7 +128,7 @@ func TestTimestampSignerUnsign(t *testing.T) {
 				defer func() { NowFunc = time.Now }()
 			}
 
-			sig := NewTimestampSigner("secret_key", "salt", "", "", nil, nil)
+			sig := NewTimestampSigner("secret_key", "salt")
 
 			actual, err := sig.Unsign(test.input, test.maxAge)
 			if test.expectError {

--- a/signer_test.go
+++ b/signer_test.go
@@ -1,9 +1,11 @@
-package itsdangerous
+package itsdangerous_test
 
 import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/junohq/go-itsdangerous"
 )
 
 // Example values here generated from Python using generate_examples.py script
@@ -19,7 +21,7 @@ func TestSignerSign(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.input, func(t *testing.T) {
-			sig := NewSigner("secret_key", "salt")
+			sig := itsdangerous.NewSigner("secret_key", "salt")
 
 			actual := sig.Sign(test.input)
 			if actual != test.expected {
@@ -43,14 +45,14 @@ func TestSignerUnsign(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.input, func(t *testing.T) {
-			sig := NewSigner("secret_key", "salt")
+			sig := itsdangerous.NewSigner("secret_key", "salt")
 
 			actual, err := sig.Unsign(test.input)
 			if test.expectError {
 				if err == nil {
 					t.Fatalf("Unsign(%s) expected error; got no error", test.input)
 				}
-				if !errors.As(err, &InvalidSignatureError{}) {
+				if !errors.As(err, &itsdangerous.InvalidSignatureError{}) {
 					t.Fatalf("Unsign(%s) expected InvalidSignatureError; got %T(%s)", test.input, err, err.Error())
 				}
 			} else {
@@ -83,11 +85,11 @@ func TestTimestampSignerSign(t *testing.T) {
 		test := test
 		t.Run(test.input, func(t *testing.T) {
 			if !test.now.IsZero() {
-				NowFunc = func() time.Time { return test.now }
-				defer func() { NowFunc = time.Now }()
+				itsdangerous.NowFunc = func() time.Time { return test.now }
+				defer func() { itsdangerous.NowFunc = time.Now }()
 			}
 
-			sig := NewTimestampSigner("secret_key", "salt")
+			sig := itsdangerous.NewTimestampSigner("secret_key", "salt")
 
 			actual := sig.Sign(test.input)
 			if actual != test.expected {
@@ -128,26 +130,26 @@ func TestTimestampSignerUnsign(t *testing.T) {
 		test := test
 		t.Run(test.input, func(t *testing.T) {
 			if !test.now.IsZero() {
-				NowFunc = func() time.Time { return test.now }
-				defer func() { NowFunc = time.Now }()
+				itsdangerous.NowFunc = func() time.Time { return test.now }
+				defer func() { itsdangerous.NowFunc = time.Now }()
 			}
 
-			sig := NewTimestampSigner("secret_key", "salt")
+			sig := itsdangerous.NewTimestampSigner("secret_key", "salt")
 
 			actual, err := sig.Unsign(test.input, test.maxAge)
 			if test.expectError {
 				if err == nil {
 					t.Fatalf("Unsign(%s) expected error; got no error", test.input)
 				}
-				if !errors.As(err, &InvalidSignatureError{}) {
+				if !errors.As(err, &itsdangerous.InvalidSignatureError{}) {
 					t.Fatalf("Unsign(%s) expected InvalidSignatureError; got %T(%s)", test.input, err, err.Error())
 				}
 				if test.expectExpired {
-					if !errors.As(err, &SignatureExpiredError{}) {
+					if !errors.As(err, &itsdangerous.SignatureExpiredError{}) {
 						t.Fatalf("Unsign(%s) expected SignatureExpiredError; got %T(%s)", test.input, err, err.Error())
 					}
 				} else {
-					if errors.As(err, &SignatureExpiredError{}) {
+					if errors.As(err, &itsdangerous.SignatureExpiredError{}) {
 						t.Fatalf("Unsign(%s) expected not to get a SignatureExpiredError; got %s", test.input, err.Error())
 					}
 				}


### PR DESCRIPTION
## What

Refine the public interface of this package:

* Change names to match the Python version where it makes sense to.
* Remove unnecessary bits from the public interface.
* Fix the types of some method params to better reflect what they are (`[]byte` vs `string` etc.)
* Introduce some error type to make it easier to check errors in consuming code.
* Simplify the default constructors.

## Why

Get the public API interface right before we start tagging releases and using this in anger so that it's easier to maintain backwards compatibility in future releases.

## Notes for reviewer.

This is a fairly large refactoring of the API surface etc, although the core algorithms are unchanged.  This may be easier to review commit-by-commit